### PR TITLE
tweaks to windowsrules and environment variables for nvidia users

### DIFF
--- a/etc/skel/.config/hypr/config/environment.lua
+++ b/etc/skel/.config/hypr/config/environment.lua
@@ -1,2 +1,10 @@
--- Environmental variables
+-- Environmental variables (for reference https://wiki.hypr.land/Configuring/Advanced-and-Cool/Environment-variables/)
+-- if you use UWSM, define your variables in ~/.config/uwsm/env
 -- if you don't use UWSM, define your variables here (e.g. hl.env("QT_QPA_PLATFORM", "wayland"))
+
+-- if you have an NVIDIA GPU uncomment the following lines:
+
+-- hl.env("GBM_BACKEND", "nvidia-drm") -- force GBM as a backend
+-- hl.env("__GLX_VENDOR_LIBRARY_NAME", "nvidia") -- force GBM as a backend
+-- hl.env("LIBVA_DRIVER_NAME", "nvidia") -- Hardware acceleration on NVIDIA GPUs
+-- hl.env("__GL_GSYNC_ALLOWED", "1") -- Controls if G-Sync capable monitors should use Variable Refresh Rate (VRR)

--- a/etc/skel/.config/hypr/config/windowrules.lua
+++ b/etc/skel/.config/hypr/config/windowrules.lua
@@ -53,7 +53,7 @@ hl.window_rule({
 hl.window_rule({ match = { class = "^(.*\\.exe)$", float = true }, monitor = PRIMARY_MONITOR, center = true, fullscreen_state = 0 })
 hl.window_rule({ match = { class = "^(.*[Ll]auncher.*)$" }, float = true, monitor = PRIMARY_MONITOR })
 hl.window_rule({ match = { class = "^(vesktop|discord)$" }, monitor = PRIMARY_MONITOR })
-hl.window_rule({ match = { class = "^(.*[Cc]alculator.*|.*[Cc]alc.*)$" }, float = true, size = { "max(monitor_w, monitor_h)*0.17", "min(monitor_w, monitor_h)*0.43" } })
+hl.window_rule({ match = { class = "^(.*[Cc]alc.*)$" }, float = true, size = { "max(monitor_w, monitor_h)*0.17", "min(monitor_w, monitor_h)*0.43" } })
 hl.window_rule({ match = { class = "^(org\\.kde\\.keditfiletype)$" }, float = true })
 hl.window_rule({ match = { class = "^(org\\.kde\\.ark)$" }, size = { "max(monitor_w, monitor_h)*0.40", "min(monitor_w, monitor_h)*0.40" } })
 hl.window_rule({ match = { class = "^(.*satty.*)$" }, min_size = { "max(monitor_w, monitor_h)*0.35", "min(monitor_w, monitor_h)*0.35" }, float = true })

--- a/etc/skel/.config/hypr/config/windowrules.lua
+++ b/etc/skel/.config/hypr/config/windowrules.lua
@@ -51,8 +51,9 @@ hl.window_rule({
 
 -- Apps
 hl.window_rule({ match = { class = "^(.*\\.exe)$", float = true }, monitor = PRIMARY_MONITOR, center = true, fullscreen_state = 0 })
-hl.window_rule({ match = { class = "^(vesktop|discord)$" }, monitor = PRIMARY_MONITOR })
-hl.window_rule({ match = { class = "^(.*[Cc]alculator.*)$" }, float = true, size = { "max(monitor_w, monitor_h)*0.17", "min(monitor_w, monitor_h)*0.43" } })
+hl.window_rule({ match = { class = "^(.*[Ll]auncher*.*)$" }, float = true, monitor = PRIMARY_MONITOR })
+hl.window_rule({ match = { class = "^([Vv]esktop|.*[Dd]iscord)$" }, monitor = PRIMARY_MONITOR })
+hl.window_rule({ match = { class = "^(.*[Cc]alc*.*)$" }, float = true, size = { "max(monitor_w, monitor_h)*0.17", "min(monitor_w, monitor_h)*0.43" } })
 hl.window_rule({ match = { class = "^(org\\.kde\\.keditfiletype)$" }, float = true })
 hl.window_rule({ match = { class = "^(org\\.kde\\.ark)$" }, size = { "max(monitor_w, monitor_h)*0.40", "min(monitor_w, monitor_h)*0.40" } })
 hl.window_rule({ match = { class = "^(.*satty.*)$" }, min_size = { "max(monitor_w, monitor_h)*0.35", "min(monitor_w, monitor_h)*0.35" }, float = true })

--- a/etc/skel/.config/hypr/config/windowrules.lua
+++ b/etc/skel/.config/hypr/config/windowrules.lua
@@ -51,9 +51,9 @@ hl.window_rule({
 
 -- Apps
 hl.window_rule({ match = { class = "^(.*\\.exe)$", float = true }, monitor = PRIMARY_MONITOR, center = true, fullscreen_state = 0 })
-hl.window_rule({ match = { class = "^(.*[Ll]auncher*.*)$" }, float = true, monitor = PRIMARY_MONITOR })
-hl.window_rule({ match = { class = "^([Vv]esktop|.*[Dd]iscord)$" }, monitor = PRIMARY_MONITOR })
-hl.window_rule({ match = { class = "^(.*[Cc]alc*.*)$" }, float = true, size = { "max(monitor_w, monitor_h)*0.17", "min(monitor_w, monitor_h)*0.43" } })
+hl.window_rule({ match = { class = "^(.*[Ll]auncher.*)$" }, float = true, monitor = PRIMARY_MONITOR })
+hl.window_rule({ match = { class = "^(vesktop|discord)$" }, monitor = PRIMARY_MONITOR })
+hl.window_rule({ match = { class = "^(.*[Cc]alculator.*|.*[Cc]alc.*)$" }, float = true, size = { "max(monitor_w, monitor_h)*0.17", "min(monitor_w, monitor_h)*0.43" } })
 hl.window_rule({ match = { class = "^(org\\.kde\\.keditfiletype)$" }, float = true })
 hl.window_rule({ match = { class = "^(org\\.kde\\.ark)$" }, size = { "max(monitor_w, monitor_h)*0.40", "min(monitor_w, monitor_h)*0.40" } })
 hl.window_rule({ match = { class = "^(.*satty.*)$" }, min_size = { "max(monitor_w, monitor_h)*0.35", "min(monitor_w, monitor_h)*0.35" }, float = true })

--- a/etc/skel/.config/uwsm/env
+++ b/etc/skel/.config/uwsm/env
@@ -7,3 +7,9 @@ export HYPRCURSOR_THEME="Bibata-Modern-Ice"
 export HYPRCURSOR_SIZE=24
 export XCURSOR_THEME="Bibata-Modern-Ice"
 export XCURSOR_SIZE=24
+
+# If you have an NVIDIA GPU uncommment the following lines
+# export GBM_BACKEND=nvidia-drm # force GBM as a backend
+# export __GLX_VENDOR_LIBRARY_NAME=nvidia # force GBM as a backend
+# export LIBVA_DRIVER_NAME=nvidia # Hardware acceleration on NVIDIA GPUs
+# export __GL_GSYNC_ALLOWED=1 # Controls if G-Sync capable monitors should use Variable Refresh Rate (VRR)


### PR DESCRIPTION
had to tweak a bit to get some stuff to work and thought id upstream it:

added some variables in environment.lua and uwsm/env for nvidia users
fixed vesktop / discord detection works (tested on flatpaks and native apps)
change calculator to calc to include more options (kcalc for example)
added general launcher recognition to floating windows (tested on prismlauncher flatpak and hytale launcher appimage)