### PR TITLE
Fix Swash window rule leftover Satty title match

### DIFF
--- a/etc/skel/.config/hypr/config/windowrules.lua
+++ b/etc/skel/.config/hypr/config/windowrules.lua
@@ -52,7 +52,7 @@ hl.window_rule({ match = { class = "^(vesktop|discord)$" }, monitor = PRIMARY_MO
 hl.window_rule({ match = { class = "^(.*[Cc]alc.*)$" }, float = true, size = { "max(monitor_w, monitor_h)*0.17", "min(monitor_w, monitor_h)*0.43" } })
 hl.window_rule({ match = { class = "^(org\\.kde\\.keditfiletype)$" }, float = true })
 hl.window_rule({ match = { class = "^(org\\.kde\\.ark)$" }, size = { "max(monitor_w, monitor_h)*0.40", "min(monitor_w, monitor_h)*0.40" } })
-hl.window_rule({ match = { class = "^(.*swash)$", title = "^(Satty)$" }, min_size = { "max(monitor_w, monitor_h)*0.35", "min(monitor_w, monitor_h)*0.35" }, float = true })
+hl.window_rule({ match = { class = "^(dev\\.lemmy\\.swash)$" }, min_size = { "max(monitor_w, monitor_h)*0.35", "min(monitor_w, monitor_h)*0.35" }, float = true })
 hl.window_rule({ match = { class = "^(dev\\.)?(noctalia\\.Noctalia(\\.Settings)?)$" }, float = true, size = { "monitor_w*0.70", "monitor_h*0.70" } })
 hl.window_rule({
     match = {


### PR DESCRIPTION
## Summary
- After #26/#28 the screenshot annotator is Swash (`dev.lemmy.swash`), but the float/min_size window rule still required `title = "^(Satty)$"`.
- Hyprland AND-matches class and title, so the rule never applied. Swash's desktop name is Swash, and `--name` can also put a filename in the title.
- Match on the documented app id only, same pattern as the nearby KDE rules.

## Test plan
- [ ] Print-screen into Swash on Hyprland 0.56.x
- [ ] Annotator window floats and respects the min size
- [ ] `hyprctl clients` shows class `dev.lemmy.swash` without title Satty