### PR TITLE
Document Swash screenshots and Super+digit monitor focus

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ You will want to configure a few user-specific things after setup. More reading 
   * Define your number of workspaces per monitor. Do not exceed 10.
 * `inputs.lua` You can define your various hypr input settings here. You'll probably want to adjust the `sensitivity`.
 * `binds.lua` Review this file to see all the keybinds for these dots. Add/remove binds that reference MONITOR# to scale it for your setup.
+  * Super+[1-3] focuses MONITOR1/2/3 (physical number-row keys). This is not a workspace switch.
+  * Super+Alt+[0-9] focuses workspace N absolutely. Super+Control+[0-9] focuses workspace N relative to the current monitor. Super+Shift+[1-3] moves the focused window to a monitor. Super+Control+Shift+[0-9] moves it to a relative workspace without following.
 * `windowrules.lua` If you find yourself wondering why certain windows have certain behaviors check this file; you can also add/remove rules as you see fit
 * `workspaces.lua` Add various workspace settings here. see examples, I recommend added 3 workspaces per monitor (shown) plus the gaming workspace to the primary monitor.
 * `environment.lua` is used for setting hypr or user specific environmental variables. not required to adjust, and it's preferable to add these to UWSM instead (see below).
@@ -51,3 +53,6 @@ You will want to configure a few user-specific things after setup. More reading 
 ### Location `noctalia settings` (Super + Z)
 * You can edit Noctalia settings here. I'd recommend going to the templates section and turning on any color templates for any apps you may use.
 * Also check out the plugins store for useful official and community plugins.
+
+## Screenshots
+Print-screen region/fullscreen pipes into Swash (not Satty). To skip the annotator, set copy to clipboard or save to file in Noctalia settings > shell > screenshot.


### PR DESCRIPTION
## Summary
- README now states that Super+[1-3] focuses MONITOR1/2/3 (physical number-row keys after #29), not workspaces.
- Workspace switch is Super+Alt (absolute) / Super+Control (relative); Super+Shift+[1-3] moves a window to a monitor.
- Screenshot note: Print-screen pipes into Swash, not Satty. Skip the annotator from Noctalia settings > shell > screenshot.

Companion wiki PR: https://github.com/CachyOS/wiki/pull/637
Related: #32 (Swash window rule). No PKGBUILD/pkgver bump.

## Test plan
- [ ] Compare `etc/skel/.config/hypr/config/binds.lua` Super+digit binds to the README bullets
- [ ] Confirm `inputs.lua` filename is already correct in README
- [ ] Confirm screenshot pipe in `config.toml` is Swash