### PR TITLE
update scrolling comment

### DIFF
--- a/etc/skel/.config/hypr/config/workspaces.lua
+++ b/etc/skel/.config/hypr/config/workspaces.lua
@@ -9,4 +9,4 @@ hl.workspace_rule({ workspace = "3", monitor = MONITOR1, default = true, persist
 -- hl.workspace_rule({ workspace = "6", monitor = MONITOR2, default = true, persistent = true })
 
 -- For other layouts such as scrolling, see example below
--- hl.workspace_rule({ workspace = "1", monitor = MONITOR1, default = true, persistent = true, layout = scroling })
+-- hl.workspace_rule({ workspace = "1", monitor = MONITOR1, default = true, persistent = true, layout = "scrolling" })


### PR DESCRIPTION
This commit fixes a comment typo in `workspaces.lua`.  Updating the type will help users more easily configure "scrolling" mode.